### PR TITLE
Reduce system.dungeon logspam

### DIFF
--- a/Content.Server/Procedural/DungeonJob/DungeonJob.Ore.cs
+++ b/Content.Server/Procedural/DungeonJob/DungeonJob.Ore.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Threading.Tasks;
 using Content.Shared.Procedural;
 using Content.Shared.Procedural.Components;
@@ -19,6 +20,8 @@ public sealed partial class DungeonJob
         HashSet<Vector2i> reservedTiles,
         Random random)
     {
+        var remaining = new Dictionary<EntProtoId, int>();
+
         foreach (var dungeon in dungeons)
         {
             var emptyTiles = false;
@@ -143,9 +146,20 @@ public sealed partial class DungeonJob
 
                 if (groupSize > 0)
                 {
-                    _sawmill.Warning($"Found remaining group size for ore veins of {gen.Replacement ?? "null"}!");
+                    var key = gen.Replacement ?? "null";
+                    if (remaining.ContainsKey(key))
+                    {
+                        remaining[key]++;
+                    }
+                    else
+                    {
+                        remaining.Add(key, 1);
+                    }
                 }
             }
         }
+        
+        if (remaining.Count > 0)
+            _sawmill.Warning($"Found remaining group size for groups, ore veins of {String.Join(", ", remaining.Select(kvp => $"{kvp.Key}: {kvp.Value}"))}!");
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Drastically reduced the amount of `system.dungeon` log spam
Instead of ~1k lines of log spam, it now prints the line, the ore vein in question, and the amount of times it had the issue

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It was sometimes severely bloating console logs, therefore I decided to fix it

## Technical details
<!-- Summary of code changes for easier review. -->
Made the log count the amount of groups with remaining group size and print at the end of the function, instead of printing every single time there was a remaining group size, reducing the total amount of lines printed by this function from ~5-10k to 5-10 per round
<img width="1027" height="312" alt="Screenshot 2025-07-27 183059" src="https://github.com/user-attachments/assets/954ba2a9-c4ad-4a24-89bf-aa7335cb9ae5" />

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
